### PR TITLE
add SVG directory to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"description": "The Red Hat Icon Font",
 	"main": "/fixtures/icon-preview.html",
 	"files": [
-		"dist/**/*"
+		"dist/**/*",
+		"src/iconfont/vectors"
 	],
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
For consideration!

Until this is published to a registry, I'd like to be able to `npm install` it to get access to the SVGs for use in pfe-icon.  Installing it directly from github is fine, but currently the `package.json`'s files property prevents the icons from being included.  This adds the vectors directory, so the SVGs are included.